### PR TITLE
 Fixed bug: Incorrect CSV returned if multiple users are using the SMAR website simultaneously 

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -207,7 +207,7 @@ const SearchBar = () => {
 
     const handleDownloadAllResults = async () => {
         try {
-            const response = await axios.get(`${SAR_BACKEND_URL}/download-csv?query=${searchQuery}`, {
+            const response = await axios.get(`${SAR_BACKEND_URL}/download-csv?query=${searchQuery}&includePermissions=${checked}`, {
                 responseType: 'blob', //handling the binary data
                 headers: {
                     // Include authorization tokens

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -24,6 +24,7 @@ import { Tooltip } from '@mui/material';
 
 const SearchBar = () => {
     const [searchQuery, setSearchQuery] = useState('');
+    const [fixedSearchQuery, setFixedSearchQuery] = useState('');
     const [searchResults, setSearchResults] = useState([]);
     const [isLoading, setIsLoading] = useState(false);
     const [totalCount, setTotalCount] = useState(0);
@@ -165,7 +166,8 @@ const SearchBar = () => {
       setAbortController(newAbortController);
       
       setIsLoading(true);
-      setSearchQuery(term); // redundant
+      setFixedSearchQuery(term);
+      
       axios.get(`${SAR_BACKEND_URL}/search?query=${term}&includePermissions=${checked}`, {
         signal: newAbortController.signal
       })
@@ -207,7 +209,7 @@ const SearchBar = () => {
 
     const handleDownloadAllResults = async () => {
         try {
-            const response = await axios.get(`${SAR_BACKEND_URL}/download-csv?query=${searchQuery}&includePermissions=${checked}`, {
+            const response = await axios.get(`${SAR_BACKEND_URL}/download-csv?query=${fixedSearchQuery}&includePermissions=${checked}`, {
                 responseType: 'blob', //handling the binary data
                 headers: {
                     // Include authorization tokens

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -161,12 +161,11 @@ const SearchBar = () => {
       if (abortController) {
         abortController.abort();
       }
-  
       const newAbortController = new AbortController();
       setAbortController(newAbortController);
       
       setIsLoading(true);
-
+      setSearchQuery(term); // redundant
       axios.get(`${SAR_BACKEND_URL}/search?query=${term}&includePermissions=${checked}`, {
         signal: newAbortController.signal
       })
@@ -208,7 +207,7 @@ const SearchBar = () => {
 
     const handleDownloadAllResults = async () => {
         try {
-            const response = await axios.get(`${SAR_BACKEND_URL}/download-csv`, {
+            const response = await axios.get(`${SAR_BACKEND_URL}/download-csv?query=${searchQuery}`, {
                 responseType: 'blob', //handling the binary data
                 headers: {
                     // Include authorization tokens


### PR DESCRIPTION
I edited the searchBar.js file to allow it to pass the query and checked parameters to the backend when calling "handleDownloadAllResults". This allows for the backend to use these parameters to fetch the CSV corresponding to the user's search term, even when multiple users are utilizing the tool at once. Furthermore, I have added an additional constant to the file to store the initial search query. This resolves an issue in which the user would be unable to retrieve the correct CSV if they modified the search term after completing a search.