### PR TITLE
Feature: Mention reproducibility log in download button

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -328,7 +328,7 @@ const SearchBar = () => {
                         onClick={handleDownloadAllResults}
                         className="download-button"
                       >
-                        Download {totalCount} Results
+                        Download ({totalCount} Results + Reproducibility Log)
                       </Button>
                     </div>
                   </div>


### PR DESCRIPTION
Update download button to reflect reproducibility log will be added to results

Current wording is "Download ({totalCount} Results + Reproducibility Log)"

We can change this to other wording that may sound better.