### PR TITLE
Fix routing refresh bug for scraper and top list pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import "./css/App.css";
+import { useState } from "react";
 import { Routes, Route, useNavigate } from "react-router-dom";
 import Home from "./pages/Home";
 import About from "./pages/About";
@@ -10,33 +11,19 @@ import { ScraperProvider } from "./components/SelectedScraperProvider";
 function App() {
     const navigate = useNavigate();
 
-    let curHomeState = "HOMEPAGE";
-    let curTopListState = "SEARCHPAGE";
+    const [showSearchResults, setShowSearchResults] = useState(false);
+
+    const flipState = () => {
+        if (!showSearchResults) setShowSearchResults(true);
+    };
 
     const refresh = () => {
-        if (curHomeState === "SEARCH_RESULTS") {
-            window.location.reload();
-        }
+        if (showSearchResults) window.location.reload();
     };
 
     const refreshTopLists = () => {
         navigate("/toplists", { state: { selectedScraper: "Play Store" } });
-    };
-
-    const flipState = () => {
-        if (curHomeState === "HOMEPAGE") {
-            curHomeState = "SEARCH_RESULTS";
-        } else {
-            curHomeState = "HOMEPAGE";
-        }
-    };
-
-    const flipTopListState = () => {
-        if (curTopListState === "SEARCHPAGE") {
-            curTopListState = "RESULTSPAGE";
-        } else {
-            curTopListState = "SEARCHPAGE";
-        }
+        refresh();
     };
 
     return (
@@ -50,7 +37,7 @@ function App() {
                     <Route path="/" element={<Home flipState={flipState} />} />
                     <Route
                         path="/toplists"
-                        element={<TopCharts flipState={flipTopListState} />}
+                        element={<TopCharts flipState={flipState} />}
                     />
                     <Route path="/userguide" element={<UserGuide />} />
                     <Route path="/about" element={<About />} />

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -257,6 +257,7 @@ const SearchBar = ({ flipState }) => {
     return (
         <div className="search-bar-container">
             <div className="search-and-button-container">
+                <Dropdown handler={handleCountryChange} />
                 <TextField
                     label="Scrape by keyword (e.g., puzzle games) or package name (e.g., com.facebook.katana)"
                     variant="outlined"
@@ -286,7 +287,6 @@ const SearchBar = ({ flipState }) => {
                     alignItems="center"
                     spacing={3}
                 >
-                    <Dropdown handler={handleCountryChange} />
                     {selectedScraper === "Play Store" && (
                         <div className="permissions-checkbox">
                             <Stack

--- a/src/components/SelectedScraperProvider.jsx
+++ b/src/components/SelectedScraperProvider.jsx
@@ -20,6 +20,8 @@ export const ScraperProvider = ({ children }) => {
         const storedScraper = localStorage.getItem("selectedScraper");
         if (storedScraper) {
             setSelectedScraper(JSON.parse(storedScraper));
+        } else {
+            setSelectedScraper("Play Store"); // Default to "Play Store"
         }
     }, []);
 


### PR DESCRIPTION
This PR implements the following changes:
1. Calls the refresh function when navigating to the top lists page from the navigation bar
2. Combines the refresh function for both the top lists and home pages